### PR TITLE
Activate isort rule in ruff and bump mypy version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,7 +108,7 @@ repos:
           - '88'
         files: (docs/.)
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.11.0
     hooks:
       - id: mypy
         files: src|tests

--- a/.tools/envs/testenv-linux.yml
+++ b/.tools/envs/testenv-linux.yml
@@ -21,7 +21,7 @@ dependencies:
   - scipy>=1.2.1  # run, tests
   - sqlalchemy  # run, tests
   - seaborn  # dev, tests
-  - mypy>=1.10  # dev, tests
+  - mypy>=1.11  # dev, tests
   - pyyaml  # dev, tests
   - jinja2  # dev, tests
   - pip:  # dev, tests, docs

--- a/.tools/envs/testenv-others.yml
+++ b/.tools/envs/testenv-others.yml
@@ -20,7 +20,7 @@ dependencies:
   - scipy>=1.2.1  # run, tests
   - sqlalchemy  # run, tests
   - seaborn  # dev, tests
-  - mypy>=1.10  # dev, tests
+  - mypy>=1.11  # dev, tests
   - pyyaml  # dev, tests
   - jinja2  # dev, tests
   - pip:  # dev, tests, docs

--- a/.tools/envs/testenv-pandas.yml
+++ b/.tools/envs/testenv-pandas.yml
@@ -19,7 +19,7 @@ dependencies:
   - scipy>=1.2.1  # run, tests
   - sqlalchemy  # run, tests
   - seaborn  # dev, tests
-  - mypy>=1.10  # dev, tests
+  - mypy>=1.11  # dev, tests
   - pyyaml  # dev, tests
   - jinja2  # dev, tests
   - pip:  # dev, tests, docs

--- a/.tools/update_name_pyproject.py
+++ b/.tools/update_name_pyproject.py
@@ -1,5 +1,6 @@
-import toml
 from pathlib import Path
+
+import toml
 
 file_path = Path(__file__).parent.parent.resolve() / "pyproject.toml"
 

--- a/docs/source/explanation/why_optimization_is_hard.ipynb
+++ b/docs/source/explanation/why_optimization_is_hard.ipynb
@@ -27,8 +27,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import optimagic as om\n",
     "import numpy as np\n",
+    "import optimagic as om\n",
     "import seaborn as sns"
    ]
   },

--- a/docs/source/how_to/how_to_algorithm_selection.ipynb
+++ b/docs/source/how_to/how_to_algorithm_selection.ipynb
@@ -31,8 +31,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import optimagic as om\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "import optimagic as om"
    ]
   },
   {

--- a/docs/source/how_to/how_to_bounds.ipynb
+++ b/docs/source/how_to/how_to_bounds.ipynb
@@ -29,8 +29,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import optimagic as om\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "import optimagic as om"
    ]
   },
   {

--- a/docs/source/how_to/how_to_errors_during_optimization.ipynb
+++ b/docs/source/how_to/how_to_errors_during_optimization.ipynb
@@ -46,8 +46,8 @@
    "source": [
     "import warnings\n",
     "\n",
-    "import optimagic as om\n",
     "import numpy as np\n",
+    "import optimagic as om\n",
     "from scipy.optimize import minimize as scipy_minimize\n",
     "\n",
     "warnings.simplefilter(\"ignore\")"

--- a/docs/source/how_to/how_to_first_derivative.ipynb
+++ b/docs/source/how_to/how_to_first_derivative.ipynb
@@ -15,8 +15,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import optimagic as om\n",
     "import numpy as np\n",
+    "import optimagic as om\n",
     "import pandas as pd"
    ]
   },

--- a/docs/source/how_to/how_to_logging.ipynb
+++ b/docs/source/how_to/how_to_logging.ipynb
@@ -25,8 +25,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import optimagic as om\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "import optimagic as om"
    ]
   },
   {

--- a/docs/source/how_to/how_to_second_derivative.ipynb
+++ b/docs/source/how_to/how_to_second_derivative.ipynb
@@ -15,8 +15,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import optimagic as om\n",
     "import numpy as np\n",
+    "import optimagic as om\n",
     "import pandas as pd"
    ]
   },

--- a/docs/source/how_to/how_to_slice_plot.ipynb
+++ b/docs/source/how_to/how_to_slice_plot.ipynb
@@ -30,8 +30,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import optimagic as om\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "import optimagic as om"
    ]
   },
   {

--- a/docs/source/how_to/how_to_visualize_histories.ipynb
+++ b/docs/source/how_to/how_to_visualize_histories.ipynb
@@ -22,8 +22,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import optimagic as om\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "import optimagic as om"
    ]
   },
   {

--- a/docs/source/tutorials/numdiff_overview.ipynb
+++ b/docs/source/tutorials/numdiff_overview.ipynb
@@ -15,8 +15,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import optimagic as om\n",
     "import numpy as np\n",
+    "import optimagic as om\n",
     "import pandas as pd"
    ]
   },

--- a/docs/source/tutorials/optimization_overview.ipynb
+++ b/docs/source/tutorials/optimization_overview.ipynb
@@ -15,8 +15,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import optimagic as om\n",
     "import numpy as np\n",
+    "import optimagic as om\n",
     "import pandas as pd"
    ]
   },

--- a/environment.yml
+++ b/environment.yml
@@ -32,7 +32,7 @@ dependencies:
   - sphinx-panels  # docs
   - sphinxcontrib-bibtex  # docs
   - seaborn  # dev, tests
-  - mypy>=1.10  # dev, tests
+  - mypy>=1.11  # dev, tests
   - pyyaml  # dev, tests
   - jinja2  # dev, tests
   - furo  # dev, docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,8 @@ fix = true
 
 [tool.ruff.lint]
 select = [
+  # isort
+  "I",
   # pyflakes
   "F",
   # pycodestyle

--- a/src/estimagic/__init__.py
+++ b/src/estimagic/__init__.py
@@ -1,40 +1,38 @@
+import warnings
+from dataclasses import dataclass
+
+from optimagic import OptimizeLogReader as _OptimizeLogReader
+from optimagic import OptimizeResult as _OptimizeResult
+from optimagic import __version__
+from optimagic import check_constraints as _check_constraints
+from optimagic import convergence_plot as _convergence_plot
+from optimagic import convergence_report as _convergence_report
+from optimagic import count_free_params as _count_free_params
+from optimagic import criterion_plot as _criterion_plot
+from optimagic import first_derivative as _first_derivative
+from optimagic import get_benchmark_problems as _get_benchmark_problems
+from optimagic import maximize as _maximize
+from optimagic import minimize as _minimize
+from optimagic import params_plot as _params_plot
+from optimagic import profile_plot as _profile_plot
+from optimagic import rank_report as _rank_report
+from optimagic import run_benchmark as _run_benchmark
+from optimagic import second_derivative as _second_derivative
+from optimagic import slice_plot as _slice_plot
+from optimagic import traceback_report as _traceback_report
+from optimagic.decorators import deprecated
+
+from estimagic import utilities
+from estimagic.bootstrap import BootstrapResult, bootstrap
 from estimagic.estimate_ml import LikelihoodResult, estimate_ml
 from estimagic.estimate_msm import MomentsResult, estimate_msm
-from estimagic.msm_weighting import get_moments_cov
-from estimagic.bootstrap import BootstrapResult, bootstrap
 from estimagic.estimation_table import (
     estimation_table,
     render_html,
     render_latex,
 )
 from estimagic.lollipop_plot import lollipop_plot
-
-from optimagic import minimize as _minimize
-from optimagic import maximize as _maximize
-from optimagic import first_derivative as _first_derivative
-from optimagic import second_derivative as _second_derivative
-from optimagic import run_benchmark as _run_benchmark
-from optimagic import get_benchmark_problems as _get_benchmark_problems
-from optimagic import convergence_report as _convergence_report
-from optimagic import rank_report as _rank_report
-from optimagic import traceback_report as _traceback_report
-from optimagic import profile_plot as _profile_plot
-from optimagic import convergence_plot as _convergence_plot
-from optimagic import slice_plot as _slice_plot
-from optimagic import check_constraints as _check_constraints
-from optimagic import count_free_params as _count_free_params
-from optimagic import criterion_plot as _criterion_plot
-from optimagic import params_plot as _params_plot
-
-from estimagic import utilities
-from optimagic import OptimizeLogReader as _OptimizeLogReader
-from optimagic import OptimizeResult as _OptimizeResult
-
-from optimagic.decorators import deprecated
-import warnings
-
-from optimagic import __version__
-from dataclasses import dataclass
+from estimagic.msm_weighting import get_moments_cov
 
 MSG = (
     "estimagic.{name} has been deprecated in version 0.5.0. Use optimagic.{name} "

--- a/src/estimagic/bootstrap.py
+++ b/src/estimagic/bootstrap.py
@@ -5,16 +5,16 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
+from optimagic.batch_evaluators import joblib_batch_evaluator
+from optimagic.parameters.block_trees import matrix_to_block_tree
+from optimagic.parameters.tree_registry import get_registry
+from optimagic.utilities import get_rng
 from pybaum import leaf_names, tree_flatten, tree_just_flatten, tree_unflatten
 
-from optimagic.batch_evaluators import joblib_batch_evaluator
 from estimagic.bootstrap_ci import calculate_ci
 from estimagic.bootstrap_helpers import check_inputs
 from estimagic.bootstrap_outcomes import get_bootstrap_outcomes
 from estimagic.shared_covs import calculate_estimation_summary
-from optimagic.parameters.block_trees import matrix_to_block_tree
-from optimagic.parameters.tree_registry import get_registry
-from optimagic.utilities import get_rng
 
 
 def bootstrap(

--- a/src/estimagic/bootstrap_outcomes.py
+++ b/src/estimagic/bootstrap_outcomes.py
@@ -1,4 +1,5 @@
 from optimagic.batch_evaluators import process_batch_evaluator
+
 from estimagic.bootstrap_helpers import check_inputs
 from estimagic.bootstrap_samples import get_bootstrap_indices
 

--- a/src/estimagic/estimate_ml.py
+++ b/src/estimagic/estimate_ml.py
@@ -5,9 +5,21 @@ from typing import Any, Dict
 
 import numpy as np
 import pandas as pd
-
+from optimagic.deprecations import replace_and_warn_about_deprecated_bounds
 from optimagic.differentiation.derivatives import first_derivative, second_derivative
 from optimagic.exceptions import InvalidFunctionError, NotAvailableError
+from optimagic.optimization.optimize import maximize
+from optimagic.optimization.optimize_result import OptimizeResult
+from optimagic.parameters.block_trees import block_tree_to_matrix, matrix_to_block_tree
+from optimagic.parameters.bounds import Bounds, pre_process_bounds
+from optimagic.parameters.conversion import Converter, get_converter
+from optimagic.parameters.space_conversion import InternalParams
+from optimagic.shared.check_option_dicts import (
+    check_numdiff_options,
+    check_optimization_options,
+)
+from optimagic.utilities import get_rng, to_pickle
+
 from estimagic.ml_covs import (
     cov_cluster_robust,
     cov_hessian,
@@ -27,18 +39,6 @@ from estimagic.shared_covs import (
     transform_free_cov_to_cov,
     transform_free_values_to_params_tree,
 )
-from optimagic.optimization.optimize import maximize
-from optimagic.optimization.optimize_result import OptimizeResult
-from optimagic.parameters.block_trees import block_tree_to_matrix, matrix_to_block_tree
-from optimagic.parameters.conversion import Converter, get_converter
-from optimagic.parameters.space_conversion import InternalParams
-from optimagic.shared.check_option_dicts import (
-    check_numdiff_options,
-    check_optimization_options,
-)
-from optimagic.utilities import get_rng, to_pickle
-from optimagic.parameters.bounds import Bounds, pre_process_bounds
-from optimagic.deprecations import replace_and_warn_about_deprecated_bounds
 
 
 def estimate_ml(

--- a/src/estimagic/estimate_msm.py
+++ b/src/estimagic/estimate_msm.py
@@ -9,12 +9,33 @@ from typing import Any, Dict, Union
 
 import numpy as np
 import pandas as pd
+from optimagic.deprecations import replace_and_warn_about_deprecated_bounds
+from optimagic.differentiation.derivatives import first_derivative
+from optimagic.exceptions import InvalidFunctionError
+from optimagic.optimization.optimize import minimize
+from optimagic.optimization.optimize_result import OptimizeResult
+from optimagic.parameters.block_trees import block_tree_to_matrix, matrix_to_block_tree
+from optimagic.parameters.bounds import Bounds, pre_process_bounds
+from optimagic.parameters.conversion import Converter, get_converter
+from optimagic.parameters.space_conversion import InternalParams
+from optimagic.parameters.tree_registry import get_registry
+from optimagic.shared.check_option_dicts import (
+    check_numdiff_options,
+    check_optimization_options,
+)
+from optimagic.utilities import get_rng, to_pickle
 from pybaum import leaf_names, tree_just_flatten
 
-from optimagic.differentiation.derivatives import first_derivative
-from estimagic.msm_weighting import get_weighting_matrix
-from optimagic.exceptions import InvalidFunctionError
 from estimagic.msm_covs import cov_optimal, cov_robust
+from estimagic.msm_sensitivity import (
+    calculate_actual_sensitivity_to_noise,
+    calculate_actual_sensitivity_to_removal,
+    calculate_fundamental_sensitivity_to_noise,
+    calculate_fundamental_sensitivity_to_removal,
+    calculate_sensitivity_to_bias,
+    calculate_sensitivity_to_weighting,
+)
+from estimagic.msm_weighting import get_weighting_matrix
 from estimagic.shared_covs import (
     FreeParams,
     calculate_ci,
@@ -27,27 +48,6 @@ from estimagic.shared_covs import (
     transform_free_cov_to_cov,
     transform_free_values_to_params_tree,
 )
-from optimagic.optimization.optimize_result import OptimizeResult
-from optimagic.optimization.optimize import minimize
-from optimagic.parameters.block_trees import block_tree_to_matrix, matrix_to_block_tree
-from optimagic.parameters.conversion import Converter, get_converter
-from optimagic.parameters.space_conversion import InternalParams
-from optimagic.parameters.tree_registry import get_registry
-from estimagic.msm_sensitivity import (
-    calculate_actual_sensitivity_to_noise,
-    calculate_actual_sensitivity_to_removal,
-    calculate_fundamental_sensitivity_to_noise,
-    calculate_fundamental_sensitivity_to_removal,
-    calculate_sensitivity_to_bias,
-    calculate_sensitivity_to_weighting,
-)
-from optimagic.shared.check_option_dicts import (
-    check_numdiff_options,
-    check_optimization_options,
-)
-from optimagic.utilities import get_rng, to_pickle
-from optimagic.deprecations import replace_and_warn_about_deprecated_bounds
-from optimagic.parameters.bounds import Bounds, pre_process_bounds
 
 
 def estimate_msm(

--- a/src/estimagic/estimation_table.py
+++ b/src/estimagic/estimation_table.py
@@ -3,11 +3,10 @@ from copy import deepcopy
 from functools import partial
 from pathlib import Path
 from warnings import warn
-from optimagic.shared.compat import pd_df_map
 
 import numpy as np
 import pandas as pd
-
+from optimagic.shared.compat import pd_df_map
 
 suppress_performance_warnings = np.testing.suppress_warnings()
 suppress_performance_warnings.filter(category=pd.errors.PerformanceWarning)

--- a/src/estimagic/lollipop_plot.py
+++ b/src/estimagic/lollipop_plot.py
@@ -2,7 +2,6 @@ import math
 
 import pandas as pd
 import plotly.graph_objects as go
-
 from optimagic.config import PLOTLY_PALETTE, PLOTLY_TEMPLATE
 from optimagic.visualization.plotting_utilities import create_grid_plot, create_ind_dict
 

--- a/src/estimagic/ml_covs.py
+++ b/src/estimagic/ml_covs.py
@@ -2,10 +2,10 @@
 
 import numpy as np
 import pandas as pd
-
 from optimagic.exceptions import INVALID_INFERENCE_MSG
-from estimagic.shared_covs import process_pandas_arguments
 from optimagic.utilities import robust_inverse
+
+from estimagic.shared_covs import process_pandas_arguments
 
 
 def cov_hessian(hess):

--- a/src/estimagic/msm_covs.py
+++ b/src/estimagic/msm_covs.py
@@ -1,8 +1,8 @@
 import pandas as pd
-
 from optimagic.exceptions import INVALID_INFERENCE_MSG
-from estimagic.shared_covs import process_pandas_arguments
 from optimagic.utilities import robust_inverse
+
+from estimagic.shared_covs import process_pandas_arguments
 
 
 def cov_robust(jac, weights, moments_cov):

--- a/src/estimagic/msm_sensitivity.py
+++ b/src/estimagic/msm_sensitivity.py
@@ -11,9 +11,10 @@ epsilon 2-6: Honore, Jorgensen & de Paula
 import numpy as np
 import pandas as pd
 from optimagic.exceptions import INVALID_SENSITIVITY_MSG
+from optimagic.utilities import robust_inverse
+
 from estimagic.msm_covs import cov_robust
 from estimagic.shared_covs import process_pandas_arguments
-from optimagic.utilities import robust_inverse
 
 
 def calculate_sensitivity_to_bias(jac, weights):

--- a/src/estimagic/msm_weighting.py
+++ b/src/estimagic/msm_weighting.py
@@ -2,13 +2,13 @@ import functools
 
 import numpy as np
 import pandas as pd
+from optimagic.parameters.block_trees import block_tree_to_matrix, matrix_to_block_tree
+from optimagic.parameters.tree_registry import get_registry
+from optimagic.utilities import robust_inverse
 from pybaum import tree_just_flatten
 from scipy.linalg import block_diag
 
 from estimagic.bootstrap import bootstrap
-from optimagic.parameters.block_trees import block_tree_to_matrix, matrix_to_block_tree
-from optimagic.parameters.tree_registry import get_registry
-from optimagic.utilities import robust_inverse
 
 
 def get_moments_cov(

--- a/src/estimagic/shared_covs.py
+++ b/src/estimagic/shared_covs.py
@@ -3,10 +3,9 @@ from typing import NamedTuple
 import numpy as np
 import pandas as pd
 import scipy
-from pybaum import tree_just_flatten, tree_unflatten
-
 from optimagic.parameters.block_trees import matrix_to_block_tree
 from optimagic.parameters.tree_registry import get_registry
+from pybaum import tree_just_flatten, tree_unflatten
 
 
 def transform_covariance(

--- a/src/estimagic/utilities.py
+++ b/src/estimagic/utilities.py
@@ -1,38 +1,35 @@
+from optimagic.decorators import deprecated
+from optimagic.utilities import (
+    calculate_trustregion_initial_radius as _calculate_trustregion_initial_radius,
+)
 from optimagic.utilities import (
     chol_params_to_lower_triangular_matrix as _chol_params_to_lower_triangular_matrix,
 )
-from optimagic.utilities import cov_params_to_matrix as _cov_params_to_matrix
 from optimagic.utilities import cov_matrix_to_params as _cov_matrix_to_params
+from optimagic.utilities import (
+    cov_matrix_to_sdcorr_params as _cov_matrix_to_sdcorr_params,
+)
+from optimagic.utilities import cov_params_to_matrix as _cov_params_to_matrix
+from optimagic.utilities import cov_to_sds_and_corr as _cov_to_sds_and_corr
+from optimagic.utilities import (
+    dimension_to_number_of_triangular_elements as _dimension_to_number_of_triangular_elements,  # noqa: E501
+)
+from optimagic.utilities import get_rng as _get_rng
+from optimagic.utilities import hash_array as _hash_array
+from optimagic.utilities import isscalar as _isscalar
+from optimagic.utilities import (
+    number_of_triangular_elements_to_dimension as _number_of_triangular_elements_to_dimension,  # noqa: E501
+)
+from optimagic.utilities import propose_alternatives as _propose_alternatives
+from optimagic.utilities import read_pickle as _read_pickle
+from optimagic.utilities import robust_cholesky as _robust_cholesky
+from optimagic.utilities import robust_inverse as _robust_inverse
+from optimagic.utilities import sdcorr_params_to_matrix as _sdcorr_params_to_matrix
 from optimagic.utilities import (
     sdcorr_params_to_sds_and_corr as _sdcorr_params_to_sds_and_corr,
 )
 from optimagic.utilities import sds_and_corr_to_cov as _sds_and_corr_to_cov
-from optimagic.utilities import cov_to_sds_and_corr as _cov_to_sds_and_corr
-from optimagic.utilities import sdcorr_params_to_matrix as _sdcorr_params_to_matrix
-from optimagic.utilities import (
-    cov_matrix_to_sdcorr_params as _cov_matrix_to_sdcorr_params,
-)
-from optimagic.utilities import (
-    number_of_triangular_elements_to_dimension as _number_of_triangular_elements_to_dimension,  # noqa: E501
-)
-from optimagic.utilities import (
-    dimension_to_number_of_triangular_elements as _dimension_to_number_of_triangular_elements,  # noqa: E501
-)
-from optimagic.utilities import propose_alternatives as _propose_alternatives
-from optimagic.utilities import robust_cholesky as _robust_cholesky
-from optimagic.utilities import robust_inverse as _robust_inverse
-from optimagic.utilities import hash_array as _hash_array
-from optimagic.utilities import (
-    calculate_trustregion_initial_radius as _calculate_trustregion_initial_radius,
-)
 from optimagic.utilities import to_pickle as _to_pickle
-from optimagic.utilities import read_pickle as _read_pickle
-from optimagic.utilities import isscalar as _isscalar
-from optimagic.utilities import get_rng as _get_rng
-
-
-from optimagic.decorators import deprecated
-
 
 MSG = (
     "estimagic.utilities.{name} has been deprecated in version 0.5.0. Use optimagic."

--- a/src/optimagic/__init__.py
+++ b/src/optimagic/__init__.py
@@ -1,20 +1,21 @@
 from optimagic import utilities
+from optimagic.benchmarking.benchmark_reports import (
+    convergence_report,
+    rank_report,
+    traceback_report,
+)
 from optimagic.benchmarking.get_benchmark_problems import get_benchmark_problems
 from optimagic.benchmarking.run_benchmark import run_benchmark
-from optimagic.benchmarking.benchmark_reports import convergence_report
-from optimagic.benchmarking.benchmark_reports import rank_report
-from optimagic.benchmarking.benchmark_reports import traceback_report
 from optimagic.differentiation.derivatives import first_derivative, second_derivative
 from optimagic.logging.read_log import OptimizeLogReader
 from optimagic.optimization.optimize import maximize, minimize
 from optimagic.optimization.optimize_result import OptimizeResult
+from optimagic.parameters.bounds import Bounds
 from optimagic.parameters.constraint_tools import check_constraints, count_free_params
 from optimagic.visualization.convergence_plot import convergence_plot
-
 from optimagic.visualization.history_plots import criterion_plot, params_plot
 from optimagic.visualization.profile_plot import profile_plot
 from optimagic.visualization.slice_plot import slice_plot
-from optimagic.parameters.bounds import Bounds
 
 try:
     from ._version import version as __version__

--- a/src/optimagic/algorithms.py
+++ b/src/optimagic/algorithms.py
@@ -1,16 +1,16 @@
 import inspect
 
 from optimagic.optimizers import (
-    pounders,
-    scipy_optimizers,
     bhhh,
-    neldermead,
     fides,
-    tao_optimizers,
-    nag_optimizers,
     ipopt,
-    pygmo_optimizers,
+    nag_optimizers,
+    neldermead,
     nlopt_optimizers,
+    pounders,
+    pygmo_optimizers,
+    scipy_optimizers,
+    tao_optimizers,
     tranquilo,
 )
 

--- a/src/optimagic/algorithms.py
+++ b/src/optimagic/algorithms.py
@@ -40,7 +40,5 @@ for module in MODULES:
 
 
 GLOBAL_ALGORITHMS = [
-    name
-    for name, func in ALL_ALGORITHMS.items()
-    if func._algorithm_info.is_global  # type: ignore
+    name for name, func in ALL_ALGORITHMS.items() if func._algorithm_info.is_global
 ]

--- a/src/optimagic/benchmarking/benchmark_reports.py
+++ b/src/optimagic/benchmarking/benchmark_reports.py
@@ -1,8 +1,8 @@
 import pandas as pd
+
 from optimagic.benchmarking.process_benchmark_results import (
     process_benchmark_results,
 )
-
 from optimagic.visualization.profile_plot import create_solution_times
 
 

--- a/src/optimagic/benchmarking/cartis_roberts.py
+++ b/src/optimagic/benchmarking/cartis_roberts.py
@@ -18,6 +18,7 @@ Implementation is based on
 from functools import partial
 
 import numpy as np
+
 from optimagic.config import IS_NUMBA_INSTALLED
 from optimagic.parameters.bounds import Bounds
 

--- a/src/optimagic/benchmarking/run_benchmark.py
+++ b/src/optimagic/benchmarking/run_benchmark.py
@@ -9,11 +9,11 @@ TO-DO:
 """
 
 import numpy as np
+from pybaum import tree_just_flatten
 
 from optimagic import batch_evaluators
 from optimagic.algorithms import AVAILABLE_ALGORITHMS
 from optimagic.optimization.optimize import minimize
-from pybaum import tree_just_flatten
 from optimagic.parameters.tree_registry import get_registry
 
 

--- a/src/optimagic/config.py
+++ b/src/optimagic/config.py
@@ -1,8 +1,8 @@
 from pathlib import Path
-import pandas as pd
-from packaging import version
 
+import pandas as pd
 import plotly.express as px
+from packaging import version
 
 DOCS_DIR = Path(__file__).parent.parent / "docs"
 

--- a/src/optimagic/deprecations.py
+++ b/src/optimagic/deprecations.py
@@ -1,4 +1,5 @@
 import warnings
+
 from optimagic.parameters.bounds import Bounds
 
 

--- a/src/optimagic/differentiation/derivatives.py
+++ b/src/optimagic/differentiation/derivatives.py
@@ -11,14 +11,13 @@ from pybaum import tree_just_flatten as tree_leaves
 
 from optimagic import batch_evaluators
 from optimagic.config import DEFAULT_N_CORES
+from optimagic.deprecations import replace_and_warn_about_deprecated_bounds
 from optimagic.differentiation import finite_differences
 from optimagic.differentiation.generate_steps import generate_steps
 from optimagic.differentiation.richardson_extrapolation import richardson_extrapolation
 from optimagic.parameters.block_trees import hessian_to_block_tree, matrix_to_block_tree
-from optimagic.parameters.bounds import get_internal_bounds
+from optimagic.parameters.bounds import Bounds, get_internal_bounds, pre_process_bounds
 from optimagic.parameters.tree_registry import get_registry
-from optimagic.deprecations import replace_and_warn_about_deprecated_bounds
-from optimagic.parameters.bounds import Bounds, pre_process_bounds
 
 
 class Evals(NamedTuple):

--- a/src/optimagic/optimization/algo_options.py
+++ b/src/optimagic/optimization/algo_options.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-
 CONVERGENCE_FTOL_REL = 2e-9
 """float: Stop when the relative improvement between two iterations is below this.
 

--- a/src/optimagic/optimization/create_optimization_problem.py
+++ b/src/optimagic/optimization/create_optimization_problem.py
@@ -1,32 +1,31 @@
 from dataclasses import dataclass
-from typing import Callable, Literal, Any
-from optimagic.typing import PyTree
-from optimagic.parameters.bounds import Bounds, pre_process_bounds
-
 from pathlib import Path
+from typing import Any, Callable, Literal
 
+from optimagic import deprecations
+from optimagic.decorators import AlgoInfo
+from optimagic.deprecations import (
+    replace_and_warn_about_deprecated_algo_options,
+    replace_and_warn_about_deprecated_bounds,
+)
 from optimagic.exceptions import (
-    MissingInputError,
     AliasError,
+    MissingInputError,
 )
 from optimagic.optimization.check_arguments import check_optimize_kwargs
 from optimagic.optimization.get_algorithm import (
     process_user_algorithm,
 )
-from optimagic.shared.process_user_function import (
-    process_func_of_params,
-    get_kwargs_from_args,
-)
 from optimagic.optimization.scipy_aliases import (
     map_method_to_algorithm,
     split_fun_and_jac,
 )
-from optimagic import deprecations
-from optimagic.deprecations import (
-    replace_and_warn_about_deprecated_algo_options,
-    replace_and_warn_about_deprecated_bounds,
+from optimagic.parameters.bounds import Bounds, pre_process_bounds
+from optimagic.shared.process_user_function import (
+    get_kwargs_from_args,
+    process_func_of_params,
 )
-from optimagic.decorators import AlgoInfo
+from optimagic.typing import PyTree
 
 
 @dataclass(frozen=True)

--- a/src/optimagic/optimization/get_algorithm.py
+++ b/src/optimagic/optimization/get_algorithm.py
@@ -4,12 +4,12 @@ from functools import partial
 
 import numpy as np
 
+from optimagic.algorithms import ALL_ALGORITHMS
 from optimagic.batch_evaluators import process_batch_evaluator
 from optimagic.logging.read_from_database import (
     list_of_dicts_to_dict_of_lists,
 )
 from optimagic.logging.write_to_database import update_row
-from optimagic.algorithms import ALL_ALGORITHMS
 from optimagic.utilities import propose_alternatives
 
 

--- a/src/optimagic/optimization/optimize.py
+++ b/src/optimagic/optimization/optimize.py
@@ -28,6 +28,10 @@ from optimagic.logging.create_tables import (
 )
 from optimagic.logging.load_database import load_database
 from optimagic.logging.write_to_database import append_row
+from optimagic.optimization.create_optimization_problem import (
+    OptimizationProblem,
+    create_optimization_problem,
+)
 from optimagic.optimization.error_penalty import get_error_penalty_function
 from optimagic.optimization.get_algorithm import (
     get_final_algorithm,
@@ -35,25 +39,20 @@ from optimagic.optimization.get_algorithm import (
 from optimagic.optimization.internal_criterion_template import (
     internal_criterion_and_derivative_template,
 )
-from optimagic.optimization.optimization_logging import log_scheduled_steps_and_get_ids
-from optimagic.optimization.process_multistart_sample import process_multistart_sample
-from optimagic.optimization.process_results import process_internal_optimizer_result
 from optimagic.optimization.multistart import (
     WEIGHT_FUNCTIONS,
     run_multistart_optimization,
 )
+from optimagic.optimization.optimization_logging import log_scheduled_steps_and_get_ids
+from optimagic.optimization.optimize_result import OptimizeResult
+from optimagic.optimization.process_multistart_sample import process_multistart_sample
+from optimagic.optimization.process_results import process_internal_optimizer_result
+from optimagic.parameters.bounds import Bounds
 from optimagic.parameters.conversion import (
     aggregate_func_output_to_value,
     get_converter,
 )
 from optimagic.parameters.nonlinear_constraints import process_nonlinear_constraints
-
-from optimagic.parameters.bounds import Bounds
-from optimagic.optimization.create_optimization_problem import (
-    create_optimization_problem,
-    OptimizationProblem,
-)
-from optimagic.optimization.optimize_result import OptimizeResult
 
 
 def maximize(

--- a/src/optimagic/optimization/optimize_result.py
+++ b/src/optimagic/optimization/optimize_result.py
@@ -1,13 +1,13 @@
+import warnings
 from dataclasses import dataclass, field
 from typing import Any, Dict
 
 import numpy as np
 import pandas as pd
 
-from optimagic.utilities import to_pickle
 from optimagic.shared.compat import pd_df_map
-import warnings
 from optimagic.typing import PyTree
+from optimagic.utilities import to_pickle
 
 
 @dataclass

--- a/src/optimagic/optimization/scipy_aliases.py
+++ b/src/optimagic/optimization/scipy_aliases.py
@@ -1,6 +1,7 @@
-from optimagic.utilities import propose_alternatives
 import functools
+
 from optimagic.exceptions import InvalidFunctionError
+from optimagic.utilities import propose_alternatives
 
 
 def map_method_to_algorithm(method):

--- a/src/optimagic/optimizers/_pounders/bntr.py
+++ b/src/optimagic/optimizers/_pounders/bntr.py
@@ -4,6 +4,7 @@ from functools import reduce
 from typing import NamedTuple
 
 import numpy as np
+
 from optimagic.optimizers._pounders._conjugate_gradient import (
     minimize_trust_cg,
 )

--- a/src/optimagic/optimizers/fides.py
+++ b/src/optimagic/optimizers/fides.py
@@ -9,10 +9,10 @@ from optimagic.decorators import mark_minimizer
 from optimagic.exceptions import NotInstalledError
 from optimagic.optimization.algo_options import (
     CONVERGENCE_FTOL_ABS,
-    CONVERGENCE_GTOL_ABS,
-    CONVERGENCE_XTOL_ABS,
     CONVERGENCE_FTOL_REL,
+    CONVERGENCE_GTOL_ABS,
     CONVERGENCE_GTOL_REL,
+    CONVERGENCE_XTOL_ABS,
     STOPPING_MAXITER,
 )
 

--- a/src/optimagic/optimizers/nag_optimizers.py
+++ b/src/optimagic/optimizers/nag_optimizers.py
@@ -16,7 +16,6 @@ from optimagic.config import IS_DFOLS_INSTALLED, IS_PYBOBYQA_INSTALLED
 from optimagic.decorators import mark_minimizer
 from optimagic.exceptions import NotInstalledError
 from optimagic.optimization.algo_options import STOPPING_MAXFUN
-
 from optimagic.utilities import calculate_trustregion_initial_radius
 
 if IS_PYBOBYQA_INSTALLED:

--- a/src/optimagic/optimizers/nlopt_optimizers.py
+++ b/src/optimagic/optimizers/nlopt_optimizers.py
@@ -10,8 +10,8 @@ from optimagic.config import IS_NLOPT_INSTALLED
 from optimagic.decorators import mark_minimizer
 from optimagic.optimization.algo_options import (
     CONVERGENCE_FTOL_ABS,
-    CONVERGENCE_XTOL_ABS,
     CONVERGENCE_FTOL_REL,
+    CONVERGENCE_XTOL_ABS,
     CONVERGENCE_XTOL_REL,
     STOPPING_MAXFUN,
     STOPPING_MAXFUN_GLOBAL,

--- a/src/optimagic/optimizers/pounders.py
+++ b/src/optimagic/optimizers/pounders.py
@@ -7,7 +7,6 @@ import numpy as np
 from optimagic.batch_evaluators import process_batch_evaluator
 from optimagic.config import DEFAULT_N_CORES
 from optimagic.decorators import mark_minimizer
-from optimagic.optimizers._pounders.pounders_history import LeastSquaresHistory
 from optimagic.optimizers._pounders.pounders_auxiliary import (
     add_accepted_point_to_residual_model,
     add_geomtery_points_to_make_main_model_fully_linear,
@@ -24,6 +23,7 @@ from optimagic.optimizers._pounders.pounders_auxiliary import (
     update_residual_model_with_new_accepted_x,
     update_trustregion_radius,
 )
+from optimagic.optimizers._pounders.pounders_history import LeastSquaresHistory
 
 
 @mark_minimizer(

--- a/src/optimagic/optimizers/scipy_optimizers.py
+++ b/src/optimagic/optimizers/scipy_optimizers.py
@@ -43,13 +43,13 @@ from optimagic.batch_evaluators import process_batch_evaluator
 from optimagic.decorators import mark_minimizer
 from optimagic.optimization.algo_options import (
     CONVERGENCE_FTOL_ABS,
-    CONVERGENCE_GTOL_ABS,
-    CONVERGENCE_XTOL_ABS,
     CONVERGENCE_FTOL_REL,
+    CONVERGENCE_GTOL_ABS,
     CONVERGENCE_GTOL_REL,
-    CONVERGENCE_XTOL_REL,
     CONVERGENCE_SECOND_BEST_FTOL_ABS,
     CONVERGENCE_SECOND_BEST_XTOL_ABS,
+    CONVERGENCE_XTOL_ABS,
+    CONVERGENCE_XTOL_REL,
     LIMITED_MEMORY_STORAGE_LENGTH,
     MAX_LINE_SEARCH_STEPS,
     STOPPING_MAXFUN,

--- a/src/optimagic/optimizers/tranquilo.py
+++ b/src/optimagic/optimizers/tranquilo.py
@@ -1,9 +1,10 @@
 from optimagic.config import IS_TRANQUILO_INSTALLED
 
-
 if IS_TRANQUILO_INSTALLED:
-    from tranquilo.tranquilo import _tranquilo
     from functools import partial
+
+    from tranquilo.tranquilo import _tranquilo
+
     from optimagic.decorators import mark_minimizer
 
     tranquilo = mark_minimizer(

--- a/src/optimagic/parameters/bounds.py
+++ b/src/optimagic/parameters/bounds.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Any, Sequence
+
 import numpy as np
+from numpy.typing import NDArray
 from pybaum import leaf_names, tree_map
 from pybaum import tree_just_flatten as tree_leaves
+from scipy.optimize import Bounds as ScipyBounds
 
 from optimagic.exceptions import InvalidBoundsError
 from optimagic.parameters.tree_registry import get_registry
-from dataclasses import dataclass
 from optimagic.typing import PyTree, PyTreeRegistry
-from scipy.optimize import Bounds as ScipyBounds
-from typing import Sequence
-from numpy.typing import NDArray
-from typing import Any
 
 
 @dataclass(frozen=True)

--- a/src/optimagic/parameters/check_constraints.py
+++ b/src/optimagic/parameters/check_constraints.py
@@ -9,7 +9,6 @@ from functools import partial
 import numpy as np
 import pandas as pd
 
-
 from optimagic.exceptions import InvalidConstraintError, InvalidParamsError
 from optimagic.utilities import cov_params_to_matrix, sdcorr_params_to_matrix
 

--- a/src/optimagic/parameters/constraint_tools.py
+++ b/src/optimagic/parameters/constraint_tools.py
@@ -1,6 +1,6 @@
-from optimagic.parameters.conversion import get_converter
 from optimagic.deprecations import replace_and_warn_about_deprecated_bounds
 from optimagic.parameters.bounds import pre_process_bounds
+from optimagic.parameters.conversion import get_converter
 
 
 def count_free_params(

--- a/src/optimagic/parameters/conversion.py
+++ b/src/optimagic/parameters/conversion.py
@@ -1,6 +1,6 @@
 """Aggregate the multiple parameter and function output conversions into on."""
 
-from typing import NamedTuple, Callable
+from typing import Callable, NamedTuple
 
 import numpy as np
 

--- a/src/optimagic/parameters/scale_conversion.py
+++ b/src/optimagic/parameters/scale_conversion.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import NamedTuple, Callable
+from typing import Callable, NamedTuple
 
 import numpy as np
 

--- a/src/optimagic/parameters/space_conversion.py
+++ b/src/optimagic/parameters/space_conversion.py
@@ -34,7 +34,7 @@ n_internal the length of the internal parameter vector.
 """
 
 from functools import partial
-from typing import NamedTuple, Callable
+from typing import Callable, NamedTuple
 
 import numpy as np
 

--- a/src/optimagic/parameters/tree_conversion.py
+++ b/src/optimagic/parameters/tree_conversion.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Callable
+from typing import Callable, NamedTuple
 
 import numpy as np
 from pybaum import leaf_names, tree_flatten, tree_just_flatten, tree_unflatten

--- a/src/optimagic/typing.py
+++ b/src/optimagic/typing.py
@@ -1,5 +1,4 @@
 from typing import Any, Callable
 
-
 PyTree = Any
 PyTreeRegistry = dict[type | str, dict[str, Callable[[Any], Any]]]

--- a/src/optimagic/visualization/slice_plot.py
+++ b/src/optimagic/visualization/slice_plot.py
@@ -8,11 +8,11 @@ from pybaum import tree_just_flatten
 
 from optimagic.batch_evaluators import process_batch_evaluator
 from optimagic.config import DEFAULT_N_CORES, PLOTLY_TEMPLATE
+from optimagic.deprecations import replace_and_warn_about_deprecated_bounds
+from optimagic.parameters.bounds import pre_process_bounds
 from optimagic.parameters.conversion import get_converter
 from optimagic.parameters.tree_registry import get_registry
 from optimagic.visualization.plotting_utilities import combine_plots, get_layout_kwargs
-from optimagic.deprecations import replace_and_warn_about_deprecated_bounds
-from optimagic.parameters.bounds import pre_process_bounds
 
 
 def slice_plot(

--- a/tests/estimagic/test_bootstrap_ci.py
+++ b/tests/estimagic/test_bootstrap_ci.py
@@ -3,8 +3,7 @@ import itertools
 import numpy as np
 import pandas as pd
 import pytest
-from estimagic.bootstrap_ci import calculate_ci
-from estimagic.bootstrap_ci import check_inputs
+from estimagic.bootstrap_ci import calculate_ci, check_inputs
 from optimagic.parameters.tree_registry import get_registry
 from pybaum import tree_just_flatten
 

--- a/tests/estimagic/test_bootstrap_outcomes.py
+++ b/tests/estimagic/test_bootstrap_outcomes.py
@@ -3,13 +3,13 @@ import functools
 import numpy as np
 import pandas as pd
 import pytest
-from optimagic.batch_evaluators import joblib_batch_evaluator
 from estimagic.bootstrap_outcomes import (
     _get_bootstrap_outcomes_from_indices,
     get_bootstrap_outcomes,
 )
-from optimagic.utilities import get_rng
 from numpy.testing import assert_array_almost_equal as aaae
+from optimagic.batch_evaluators import joblib_batch_evaluator
+from optimagic.utilities import get_rng
 
 
 @pytest.fixture()

--- a/tests/estimagic/test_bootstrap_samples.py
+++ b/tests/estimagic/test_bootstrap_samples.py
@@ -7,8 +7,8 @@ from estimagic.bootstrap_samples import (
     get_bootstrap_indices,
     get_bootstrap_samples,
 )
-from optimagic.utilities import get_rng
 from numpy.testing import assert_array_equal as aae
+from optimagic.utilities import get_rng
 from pandas.testing import assert_frame_equal as afe
 
 

--- a/tests/estimagic/test_estimate_ml.py
+++ b/tests/estimagic/test_estimate_ml.py
@@ -9,9 +9,9 @@ from estimagic.estimate_ml import estimate_ml
 from estimagic.examples.logit import logit_derivative, logit_hessian, logit_loglike
 from estimagic.examples.logit import logit_loglike_and_derivative as llad
 from numpy.testing import assert_array_equal
+from optimagic.parameters.bounds import Bounds
 from scipy.stats import multivariate_normal
 from statsmodels.base.model import GenericLikelihoodModel
-from optimagic.parameters.bounds import Bounds
 
 
 def aaae(obj1, obj2, decimal=3):

--- a/tests/estimagic/test_estimate_msm.py
+++ b/tests/estimagic/test_estimate_msm.py
@@ -5,14 +5,14 @@ import itertools
 import numpy as np
 import pandas as pd
 import pytest
-from optimagic.optimization.optimize_result import OptimizeResult
 from estimagic.estimate_msm import estimate_msm
+from numpy.testing import assert_array_almost_equal as aaae
+from numpy.testing import assert_array_equal
+from optimagic.optimization.optimize_result import OptimizeResult
 from optimagic.shared.check_option_dicts import (
     check_numdiff_options,
     check_optimization_options,
 )
-from numpy.testing import assert_array_almost_equal as aaae
-from numpy.testing import assert_array_equal
 
 
 def _sim_pd(params):

--- a/tests/estimagic/test_estimate_msm_dict_params_and_moments.py
+++ b/tests/estimagic/test_estimate_msm_dict_params_and_moments.py
@@ -3,8 +3,8 @@
 import numpy as np
 import pandas as pd
 from estimagic.estimate_msm import estimate_msm
-from optimagic.parameters.tree_registry import get_registry
 from numpy.testing import assert_array_almost_equal as aaae
+from optimagic.parameters.tree_registry import get_registry
 from pybaum import tree_just_flatten
 
 

--- a/tests/estimagic/test_estimation_table.py
+++ b/tests/estimagic/test_estimation_table.py
@@ -8,6 +8,7 @@ import statsmodels.api as sm
 from estimagic.config import EXAMPLE_DIR
 from estimagic.estimation_table import (
     _apply_number_format,
+    _center_align_integers_and_non_numeric_strings,
     _check_order_of_model_names,
     _convert_frame_to_string_series,
     _create_group_to_col_position,
@@ -23,7 +24,6 @@ from estimagic.estimation_table import (
     estimation_table,
     render_html,
     render_latex,
-    _center_align_integers_and_non_numeric_strings,
 )
 from pandas.testing import assert_frame_equal as afe
 from pandas.testing import assert_series_equal as ase

--- a/tests/estimagic/test_msm_covs.py
+++ b/tests/estimagic/test_msm_covs.py
@@ -4,8 +4,8 @@ import numpy as np
 import pandas as pd
 import pytest
 from estimagic.msm_covs import cov_optimal, cov_robust
-from optimagic.utilities import get_rng
 from numpy.testing import assert_array_almost_equal as aaae
+from optimagic.utilities import get_rng
 from pandas.testing import assert_frame_equal
 
 rng = get_rng(seed=1234)

--- a/tests/estimagic/test_msm_sensitivity.py
+++ b/tests/estimagic/test_msm_sensitivity.py
@@ -2,7 +2,6 @@ import numpy as np
 import pandas as pd
 import pytest
 from estimagic.config import EXAMPLE_DIR
-from optimagic.differentiation.derivatives import first_derivative
 from estimagic.msm_covs import cov_optimal
 from estimagic.msm_sensitivity import (
     calculate_actual_sensitivity_to_noise,
@@ -13,6 +12,7 @@ from estimagic.msm_sensitivity import (
     calculate_sensitivity_to_weighting,
 )
 from numpy.testing import assert_array_almost_equal as aaae
+from optimagic.differentiation.derivatives import first_derivative
 from scipy import stats
 
 

--- a/tests/estimagic/test_msm_weighting.py
+++ b/tests/estimagic/test_msm_weighting.py
@@ -8,9 +8,9 @@ from estimagic.msm_weighting import (
     get_moments_cov,
     get_weighting_matrix,
 )
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.parameters.block_trees import block_tree_to_matrix
 from optimagic.utilities import get_rng
-from numpy.testing import assert_array_almost_equal as aaae
 
 
 @pytest.fixture()

--- a/tests/estimagic/test_shared.py
+++ b/tests/estimagic/test_shared.py
@@ -12,9 +12,9 @@ from estimagic.shared_covs import (
     transform_free_cov_to_cov,
     transform_free_values_to_params_tree,
 )
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.parameters.tree_registry import get_registry
 from optimagic.utilities import get_rng
-from numpy.testing import assert_array_almost_equal as aaae
 from pybaum import leaf_names, tree_equal
 
 

--- a/tests/optimagic/benchmarking/test_benchmark_reports.py
+++ b/tests/optimagic/benchmarking/test_benchmark_reports.py
@@ -1,14 +1,14 @@
-import pytest
 from itertools import product
-import numpy as np
 
+import numpy as np
+import pytest
 from optimagic import (
+    OptimizeResult,
     convergence_report,
+    get_benchmark_problems,
     rank_report,
     traceback_report,
 )
-from optimagic import OptimizeResult
-from optimagic import get_benchmark_problems
 
 
 @pytest.fixture

--- a/tests/optimagic/benchmarking/test_cartis_roberts.py
+++ b/tests/optimagic/benchmarking/test_cartis_roberts.py
@@ -1,11 +1,11 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_array_almost_equal
 from optimagic.benchmarking.cartis_roberts import (
     CARTIS_ROBERTS_PROBLEMS,
     get_start_points_bdvalues,
     get_start_points_msqrta,
 )
-from numpy.testing import assert_array_almost_equal
 
 
 @pytest.mark.parametrize("name, specification", list(CARTIS_ROBERTS_PROBLEMS.items()))

--- a/tests/optimagic/differentiation/test_compare_derivatives_with_jax.py
+++ b/tests/optimagic/differentiation/test_compare_derivatives_with_jax.py
@@ -6,9 +6,9 @@ This test module only runs if jax is installed.
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.config import IS_JAX_INSTALLED
 from optimagic.differentiation.derivatives import first_derivative, second_derivative
-from numpy.testing import assert_array_almost_equal as aaae
 from pybaum import tree_equal
 
 if not IS_JAX_INSTALLED:

--- a/tests/optimagic/differentiation/test_derivatives.py
+++ b/tests/optimagic/differentiation/test_derivatives.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.differentiation.derivatives import (
     Evals,
     _consolidate_one_step_derivatives,
@@ -26,10 +27,9 @@ from optimagic.examples.numdiff_functions import (
     logit_loglikeobs,
     logit_loglikeobs_jacobian,
 )
-from numpy.testing import assert_array_almost_equal as aaae
+from optimagic.parameters.bounds import Bounds
 from pandas.testing import assert_frame_equal
 from scipy.optimize._numdiff import approx_derivative
-from optimagic.parameters.bounds import Bounds
 
 
 @pytest.fixture()

--- a/tests/optimagic/differentiation/test_finite_differences.py
+++ b/tests/optimagic/differentiation/test_finite_differences.py
@@ -1,9 +1,9 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.differentiation.derivatives import Evals
 from optimagic.differentiation.finite_differences import jacobian
 from optimagic.differentiation.generate_steps import Steps
-from numpy.testing import assert_array_almost_equal as aaae
 
 
 @pytest.fixture()

--- a/tests/optimagic/differentiation/test_generate_steps.py
+++ b/tests/optimagic/differentiation/test_generate_steps.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.differentiation.generate_steps import (
     _calculate_or_validate_base_steps,
     _fillna,
@@ -7,7 +8,6 @@ from optimagic.differentiation.generate_steps import (
     _set_unused_side_to_nan,
     generate_steps,
 )
-from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.parameters.bounds import Bounds
 
 

--- a/tests/optimagic/examples/test_criterion_functions.py
+++ b/tests/optimagic/examples/test_criterion_functions.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from numpy.testing import assert_allclose, assert_array_equal
 from optimagic.examples.criterion_functions import (
     rosenbrock_criterion_and_gradient,
     rosenbrock_dict_criterion,
@@ -15,7 +16,6 @@ from optimagic.examples.criterion_functions import (
     trid_gradient,
     trid_scalar_criterion,
 )
-from numpy.testing import assert_allclose, assert_array_equal
 
 
 # Fix input params to test every criterion function

--- a/tests/optimagic/logging/test_database_utilities.py
+++ b/tests/optimagic/logging/test_database_utilities.py
@@ -2,6 +2,7 @@ import pickle
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 from optimagic.logging.create_tables import (
     make_optimization_iteration_table,
     make_optimization_problem_table,
@@ -14,7 +15,6 @@ from optimagic.logging.read_from_database import (
     read_table,
 )
 from optimagic.logging.write_to_database import append_row, update_row
-from numpy.testing import assert_array_equal
 
 
 @pytest.fixture()

--- a/tests/optimagic/optimization/test_convergence_report.py
+++ b/tests/optimagic/optimization/test_convergence_report.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
-from optimagic.optimization.convergence_report import get_convergence_report
 from numpy.testing import assert_array_almost_equal as aaae
+from optimagic.optimization.convergence_report import get_convergence_report
 
 
 def test_get_convergence_report_minimize():

--- a/tests/optimagic/optimization/test_criterion_versions.py
+++ b/tests/optimagic/optimization/test_criterion_versions.py
@@ -10,6 +10,7 @@ Here we want to take:
 import numpy as np
 import pandas as pd
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.config import IS_DFOLS_INSTALLED
 from optimagic.examples.criterion_functions import (
     sos_dict_criterion,
@@ -18,7 +19,6 @@ from optimagic.examples.criterion_functions import (
 )
 from optimagic.exceptions import InvalidFunctionError
 from optimagic.optimization.optimize import minimize
-from numpy.testing import assert_array_almost_equal as aaae
 
 algorithms = ["scipy_lbfgsb", "scipy_neldermead"]
 if IS_DFOLS_INSTALLED:

--- a/tests/optimagic/optimization/test_derivative_versions.py
+++ b/tests/optimagic/optimization/test_derivative_versions.py
@@ -11,6 +11,7 @@ Here we want to take:
 import numpy as np
 import pandas as pd
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.decorators import switch_sign
 from optimagic.examples.criterion_functions import (
     sos_criterion_and_gradient,
@@ -23,7 +24,6 @@ from optimagic.examples.criterion_functions import (
     sos_pandas_jacobian,
 )
 from optimagic.optimization.optimize import maximize, minimize
-from numpy.testing import assert_array_almost_equal as aaae
 
 algorithms = ["scipy_lbfgsb", "scipy_neldermead", "scipy_ls_dogbox"]
 

--- a/tests/optimagic/optimization/test_error_penalty.py
+++ b/tests/optimagic/optimization/test_error_penalty.py
@@ -2,6 +2,7 @@ import functools
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.differentiation.derivatives import first_derivative
 from optimagic.optimization.error_penalty import (
     _penalty_contributions,
@@ -13,7 +14,6 @@ from optimagic.optimization.error_penalty import (
     get_error_penalty_function,
 )
 from optimagic.utilities import get_rng
-from numpy.testing import assert_array_almost_equal as aaae
 
 
 @pytest.mark.parametrize("seed", range(10))

--- a/tests/optimagic/optimization/test_history_collection.py
+++ b/tests/optimagic/optimization/test_history_collection.py
@@ -2,12 +2,12 @@ import sys
 
 import numpy as np
 import pytest
-from optimagic.logging.read_log import OptimizeLogReader
-from optimagic.algorithms import AVAILABLE_ALGORITHMS
-from optimagic.optimization.optimize import minimize
 from numpy.testing import assert_array_almost_equal as aaae
 from numpy.testing import assert_array_equal as aae
+from optimagic.algorithms import AVAILABLE_ALGORITHMS
 from optimagic.decorators import mark_minimizer
+from optimagic.logging.read_log import OptimizeLogReader
+from optimagic.optimization.optimize import minimize
 from optimagic.parameters.bounds import Bounds
 
 OPTIMIZERS = []

--- a/tests/optimagic/optimization/test_history_tools.py
+++ b/tests/optimagic/optimization/test_history_tools.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
-from optimagic.optimization.history_tools import get_history_arrays
 from numpy.testing import assert_array_almost_equal as aaae
+from optimagic.optimization.history_tools import get_history_arrays
 
 
 @pytest.fixture()

--- a/tests/optimagic/optimization/test_internal_criterion_and_derivative_template.py
+++ b/tests/optimagic/optimization/test_internal_criterion_and_derivative_template.py
@@ -3,6 +3,7 @@ import itertools
 import numpy as np
 import pandas as pd
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.decorators import AlgoInfo
 from optimagic.examples.criterion_functions import (
     sos_criterion_and_gradient,
@@ -16,7 +17,6 @@ from optimagic.optimization.internal_criterion_template import (
     internal_criterion_and_derivative_template,
 )
 from optimagic.parameters.conversion import get_converter
-from numpy.testing import assert_array_almost_equal as aaae
 
 
 def reparametrize_from_internal(x):

--- a/tests/optimagic/optimization/test_jax_derivatives.py
+++ b/tests/optimagic/optimization/test_jax_derivatives.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.config import IS_JAX_INSTALLED
 from optimagic.optimization.optimize import minimize
-from numpy.testing import assert_array_almost_equal as aaae
 
 if IS_JAX_INSTALLED:
     import jax

--- a/tests/optimagic/optimization/test_many_algorithms.py
+++ b/tests/optimagic/optimization/test_many_algorithms.py
@@ -10,9 +10,9 @@ import sys
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.algorithms import AVAILABLE_ALGORITHMS, GLOBAL_ALGORITHMS
 from optimagic.optimization.optimize import minimize
-from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.parameters.bounds import Bounds
 
 LOCAL_ALGORITHMS = {

--- a/tests/optimagic/optimization/test_multistart.py
+++ b/tests/optimagic/optimization/test_multistart.py
@@ -3,6 +3,7 @@ from itertools import product
 import numpy as np
 import pandas as pd
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.optimization.multistart import (
     _linear_weights,
     _tiktak_weights,
@@ -11,7 +12,6 @@ from optimagic.optimization.multistart import (
     run_explorations,
     update_convergence_state,
 )
-from numpy.testing import assert_array_almost_equal as aaae
 
 
 @pytest.fixture()

--- a/tests/optimagic/optimization/test_optimizations_with_scaling.py
+++ b/tests/optimagic/optimization/test_optimizations_with_scaling.py
@@ -5,9 +5,9 @@ import itertools
 import numpy as np
 import pandas as pd
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.config import IS_PYBOBYQA_INSTALLED
 from optimagic.optimization.optimize import minimize
-from numpy.testing import assert_array_almost_equal as aaae
 
 ALGORITHMS = ["scipy_lbfgsb"]
 

--- a/tests/optimagic/optimization/test_optimize.py
+++ b/tests/optimagic/optimization/test_optimize.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from optimagic.examples.criterion_functions import sos_scalar_criterion
-from optimagic.exceptions import InvalidKwargsError, InvalidFunctionError
+from optimagic.exceptions import InvalidFunctionError, InvalidKwargsError
 from optimagic.optimization.optimize import maximize, minimize
 
 

--- a/tests/optimagic/optimization/test_params_versions.py
+++ b/tests/optimagic/optimization/test_params_versions.py
@@ -1,10 +1,10 @@
 import numpy as np
 import pandas as pd
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.differentiation.derivatives import first_derivative
 from optimagic.optimization.optimize import minimize
 from optimagic.parameters.tree_registry import get_registry
-from numpy.testing import assert_array_almost_equal as aaae
 from pybaum import tree_just_flatten, tree_map
 
 REGISTRY = get_registry(extended=True)

--- a/tests/optimagic/optimization/test_process_multistart_sample.py
+++ b/tests/optimagic/optimization/test_process_multistart_sample.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pandas as pd
 import pytest
-from optimagic.optimization.process_multistart_sample import process_multistart_sample
 from numpy.testing import assert_array_almost_equal as aaae
+from optimagic.optimization.process_multistart_sample import process_multistart_sample
 
 samples = [
     (

--- a/tests/optimagic/optimization/test_scipy_aliases.py
+++ b/tests/optimagic/optimization/test_scipy_aliases.py
@@ -1,8 +1,8 @@
-import optimagic as om
 import numpy as np
+import optimagic as om
+import pytest
 from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.exceptions import AliasError
-import pytest
 
 
 def test_x0_works_in_minimize():

--- a/tests/optimagic/optimization/test_with_advanced_constraints.py
+++ b/tests/optimagic/optimization/test_with_advanced_constraints.py
@@ -11,9 +11,9 @@ import itertools
 import numpy as np
 import pandas as pd
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.examples.criterion_functions import sos_gradient, sos_scalar_criterion
 from optimagic.optimization.optimize import minimize
-from numpy.testing import assert_array_almost_equal as aaae
 
 CONSTR_INFO = {
     "cov_bounds_distance": [

--- a/tests/optimagic/optimization/test_with_bounds.py
+++ b/tests/optimagic/optimization/test_with_bounds.py
@@ -1,6 +1,6 @@
-from optimagic.optimization.optimize import minimize, maximize
-from scipy.optimize import Bounds as ScipyBounds
 import numpy as np
+from optimagic.optimization.optimize import maximize, minimize
+from scipy.optimize import Bounds as ScipyBounds
 
 
 def test_minimize_with_scipy_bounds():

--- a/tests/optimagic/optimization/test_with_constraints.py
+++ b/tests/optimagic/optimization/test_with_constraints.py
@@ -13,6 +13,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import statsmodels.api as sm
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.examples.criterion_functions import (
     rosenbrock_dict_criterion,
     rosenbrock_gradient,
@@ -27,7 +28,6 @@ from optimagic.examples.criterion_functions import (
 )
 from optimagic.exceptions import InvalidConstraintError, InvalidParamsError
 from optimagic.optimization.optimize import maximize, minimize
-from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.parameters.bounds import Bounds
 
 

--- a/tests/optimagic/optimization/test_with_logging.py
+++ b/tests/optimagic/optimization/test_with_logging.py
@@ -10,6 +10,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.examples.criterion_functions import (
     sos_dict_criterion,
     sos_dict_derivative,
@@ -17,7 +18,6 @@ from optimagic.examples.criterion_functions import (
 from optimagic.exceptions import TableExistsError
 from optimagic.optimization.optimize import minimize
 from optimagic.parameters.tree_registry import get_registry
-from numpy.testing import assert_array_almost_equal as aaae
 from pybaum import tree_just_flatten
 
 

--- a/tests/optimagic/optimization/test_with_multistart.py
+++ b/tests/optimagic/optimization/test_with_multistart.py
@@ -3,6 +3,7 @@ from itertools import product
 import numpy as np
 import pandas as pd
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.decorators import switch_sign
 from optimagic.examples.criterion_functions import (
     sos_dict_criterion,
@@ -13,7 +14,6 @@ from optimagic.logging.read_from_database import read_new_rows
 from optimagic.logging.read_log import read_steps_table
 from optimagic.optimization.optimize import maximize, minimize
 from optimagic.optimization.optimize_result import OptimizeResult
-from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.parameters.bounds import Bounds
 
 criteria = [sos_scalar_criterion, sos_dict_criterion]

--- a/tests/optimagic/optimization/test_with_nonlinear_constraints.py
+++ b/tests/optimagic/optimization/test_with_nonlinear_constraints.py
@@ -3,10 +3,10 @@ import warnings
 
 import numpy as np
 import pytest
-from optimagic import maximize, minimize
-from optimagic.config import IS_CYIPOPT_INSTALLED
-from optimagic.algorithms import AVAILABLE_ALGORITHMS
 from numpy.testing import assert_array_almost_equal as aaae
+from optimagic import maximize, minimize
+from optimagic.algorithms import AVAILABLE_ALGORITHMS
+from optimagic.config import IS_CYIPOPT_INSTALLED
 from optimagic.parameters.bounds import Bounds
 
 NLC_ALGORITHMS = [

--- a/tests/optimagic/optimizers/_pounders/test_linear_subsolvers.py
+++ b/tests/optimagic/optimizers/_pounders/test_linear_subsolvers.py
@@ -4,12 +4,12 @@ import math
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.optimizers._pounders.linear_subsolvers import (
     LinearModel,
     improve_geomtery_trsbox_linear,
     minimize_trsbox_linear,
 )
-from numpy.testing import assert_array_almost_equal as aaae
 
 
 @pytest.mark.parametrize(

--- a/tests/optimagic/optimizers/_pounders/test_pounders_history.py
+++ b/tests/optimagic/optimizers/_pounders/test_pounders_history.py
@@ -2,8 +2,8 @@
 
 import numpy as np
 import pytest
-from optimagic.optimizers._pounders.pounders_history import LeastSquaresHistory
 from numpy.testing import assert_array_almost_equal as aaae
+from optimagic.optimizers._pounders.pounders_history import LeastSquaresHistory
 
 ENTRIES = [
     (np.arange(3), [np.arange(5)]),

--- a/tests/optimagic/optimizers/_pounders/test_pounders_unit.py
+++ b/tests/optimagic/optimizers/_pounders/test_pounders_unit.py
@@ -2,13 +2,14 @@
 
 from collections import namedtuple
 from functools import partial
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import pytest
 import yaml
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.batch_evaluators import joblib_batch_evaluator
-from optimagic.optimizers._pounders.pounders_history import LeastSquaresHistory
 from optimagic.optimizers._pounders.pounders_auxiliary import (
     add_geomtery_points_to_make_main_model_fully_linear,
     create_initial_residual_model,
@@ -21,8 +22,7 @@ from optimagic.optimizers._pounders.pounders_auxiliary import (
     update_residual_model,
     update_residual_model_with_new_accepted_x,
 )
-from numpy.testing import assert_array_almost_equal as aaae
-from pathlib import Path
+from optimagic.optimizers._pounders.pounders_history import LeastSquaresHistory
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 

--- a/tests/optimagic/optimizers/_pounders/test_quadratic_subsolvers.py
+++ b/tests/optimagic/optimizers/_pounders/test_quadratic_subsolvers.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pytest
-from optimagic.optimizers._pounders.pounders_auxiliary import MainModel
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.optimizers._pounders._conjugate_gradient import (
     minimize_trust_cg,
 )
@@ -16,7 +16,7 @@ from optimagic.optimizers._pounders.bntr import (
 from optimagic.optimizers._pounders.gqtpar import (
     gqtpar,
 )
-from numpy.testing import assert_array_almost_equal as aaae
+from optimagic.optimizers._pounders.pounders_auxiliary import MainModel
 
 # ======================================================================================
 # Subsolver BNTR

--- a/tests/optimagic/optimizers/test_bhhh.py
+++ b/tests/optimagic/optimizers/test_bhhh.py
@@ -5,9 +5,9 @@ from functools import partial
 import numpy as np
 import pytest
 import statsmodels.api as sm
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.optimizers.bhhh import bhhh_internal
 from optimagic.utilities import get_rng
-from numpy.testing import assert_array_almost_equal as aaae
 from scipy.stats import norm
 
 

--- a/tests/optimagic/optimizers/test_fides_options.py
+++ b/tests/optimagic/optimizers/test_fides_options.py
@@ -2,12 +2,12 @@
 
 import numpy as np
 import pytest
-from optimagic.config import IS_FIDES_INSTALLED
 from numpy.testing import assert_array_almost_equal as aaae
+from optimagic.config import IS_FIDES_INSTALLED
 
 if IS_FIDES_INSTALLED:
-    from optimagic.optimizers.fides import fides
     from fides.hessian_approximation import FX, SR1, Broyden
+    from optimagic.optimizers.fides import fides
 else:
     FX = lambda: None
     SR1 = lambda: None

--- a/tests/optimagic/optimizers/test_ipopt_options.py
+++ b/tests/optimagic/optimizers/test_ipopt_options.py
@@ -2,9 +2,9 @@
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.config import IS_CYIPOPT_INSTALLED
 from optimagic.optimizers.ipopt import ipopt
-from numpy.testing import assert_array_almost_equal as aaae
 
 test_cases = [
     {},

--- a/tests/optimagic/optimizers/test_pounders_integration.py
+++ b/tests/optimagic/optimizers/test_pounders_integration.py
@@ -1,17 +1,17 @@
 """Test suite for the internal pounders interface."""
 
 import sys
-
 from functools import partial
 from itertools import product
 
 import numpy as np
 import pandas as pd
 import pytest
-from optimagic.batch_evaluators import joblib_batch_evaluator
-from tests.optimagic.optimizers._pounders.test_pounders_unit import FIXTURES_DIR
-from optimagic.optimizers.pounders import internal_solve_pounders
 from numpy.testing import assert_array_almost_equal as aaae
+from optimagic.batch_evaluators import joblib_batch_evaluator
+from optimagic.optimizers.pounders import internal_solve_pounders
+
+from tests.optimagic.optimizers._pounders.test_pounders_unit import FIXTURES_DIR
 
 
 def load_history(start_vec, solver_sub):

--- a/tests/optimagic/parameters/test_block_trees.py
+++ b/tests/optimagic/parameters/test_block_trees.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from numpy.testing import assert_array_equal
 from optimagic import second_derivative
 from optimagic.parameters.block_trees import (
     block_tree_to_hessian,
@@ -9,7 +10,6 @@ from optimagic.parameters.block_trees import (
     matrix_to_block_tree,
 )
 from optimagic.parameters.tree_registry import get_registry
-from numpy.testing import assert_array_equal
 from pybaum import tree_equal
 from pybaum import tree_just_flatten as tree_leaves
 

--- a/tests/optimagic/parameters/test_bounds.py
+++ b/tests/optimagic/parameters/test_bounds.py
@@ -1,9 +1,9 @@
 import numpy as np
 import pandas as pd
 import pytest
-from optimagic.exceptions import InvalidBoundsError
-from optimagic.parameters.bounds import get_internal_bounds, Bounds, pre_process_bounds
 from numpy.testing import assert_array_equal
+from optimagic.exceptions import InvalidBoundsError
+from optimagic.parameters.bounds import Bounds, get_internal_bounds, pre_process_bounds
 
 
 @pytest.fixture()

--- a/tests/optimagic/parameters/test_check_constraints.py
+++ b/tests/optimagic/parameters/test_check_constraints.py
@@ -1,7 +1,7 @@
 import numpy as np
-from optimagic.parameters.check_constraints import _iloc
 import pytest
 from optimagic.exceptions import InvalidParamsError
+from optimagic.parameters.check_constraints import _iloc
 from optimagic.parameters.constraint_tools import check_constraints
 
 

--- a/tests/optimagic/parameters/test_conversion.py
+++ b/tests/optimagic/parameters/test_conversion.py
@@ -1,13 +1,13 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
+from optimagic.parameters.bounds import Bounds
 from optimagic.parameters.conversion import (
     _is_fast_deriv_eval,
     _is_fast_func_eval,
     _is_fast_path,
     get_converter,
 )
-from numpy.testing import assert_array_almost_equal as aaae
-from optimagic.parameters.bounds import Bounds
 
 
 def test_get_converter_fast_case():

--- a/tests/optimagic/parameters/test_kernel_transformations.py
+++ b/tests/optimagic/parameters/test_kernel_transformations.py
@@ -1,13 +1,13 @@
 from functools import partial
 from itertools import product
 
-import optimagic.parameters.kernel_transformations as kt
 import numpy as np
+import optimagic.parameters.kernel_transformations as kt
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.differentiation.derivatives import first_derivative
 from optimagic.parameters.kernel_transformations import cov_matrix_to_sdcorr_params
 from optimagic.utilities import get_rng
-from numpy.testing import assert_array_almost_equal as aaae
 
 to_test = list(product(range(10, 30, 5), [1234, 5471]))
 

--- a/tests/optimagic/parameters/test_nonlinear_constraints.py
+++ b/tests/optimagic/parameters/test_nonlinear_constraints.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 import numpy as np
 import pandas as pd
 import pytest
+from numpy.testing import assert_array_equal
 from optimagic.exceptions import InvalidConstraintError
 from optimagic.parameters.nonlinear_constraints import (
     _check_validity_and_return_evaluation,
@@ -18,7 +19,6 @@ from optimagic.parameters.nonlinear_constraints import (
     vector_as_list_of_scalar_constraints,
 )
 from optimagic.parameters.tree_registry import get_registry
-from numpy.testing import assert_array_equal
 from pandas.testing import assert_frame_equal
 from pybaum import tree_just_flatten
 

--- a/tests/optimagic/parameters/test_process_constraints.py
+++ b/tests/optimagic/parameters/test_process_constraints.py
@@ -4,11 +4,11 @@ import numpy as np
 import pandas as pd
 import pytest
 from optimagic.exceptions import InvalidConstraintError
+from optimagic.parameters.bounds import Bounds
 from optimagic.parameters.constraint_tools import check_constraints
 from optimagic.parameters.process_constraints import (
     _replace_pairwise_equality_by_equality,
 )
-from optimagic.parameters.bounds import Bounds
 
 
 def test_replace_pairwise_equality_by_equality():

--- a/tests/optimagic/parameters/test_process_selectors.py
+++ b/tests/optimagic/parameters/test_process_selectors.py
@@ -1,11 +1,11 @@
 import numpy as np
 import pandas as pd
 import pytest
+from numpy.testing import assert_array_equal as aae
 from optimagic.exceptions import InvalidConstraintError
 from optimagic.parameters.process_selectors import process_selectors
 from optimagic.parameters.tree_conversion import TreeConverter
 from optimagic.parameters.tree_registry import get_registry
-from numpy.testing import assert_array_equal as aae
 from pybaum import tree_flatten, tree_just_flatten, tree_unflatten
 
 

--- a/tests/optimagic/parameters/test_scale_conversion.py
+++ b/tests/optimagic/parameters/test_scale_conversion.py
@@ -1,10 +1,10 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
+from numpy.testing import assert_array_equal as aae
 from optimagic import first_derivative
 from optimagic.parameters.conversion import InternalParams
 from optimagic.parameters.scale_conversion import get_scale_converter
-from numpy.testing import assert_array_almost_equal as aaae
-from numpy.testing import assert_array_equal as aae
 
 TEST_CASES = {
     "start_values": InternalParams(

--- a/tests/optimagic/parameters/test_space_conversion.py
+++ b/tests/optimagic/parameters/test_space_conversion.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic import first_derivative
 from optimagic.parameters.space_conversion import (
     InternalParams,
@@ -8,7 +9,6 @@ from optimagic.parameters.space_conversion import (
     get_space_converter,
 )
 from optimagic.utilities import get_rng
-from numpy.testing import assert_array_almost_equal as aaae
 
 
 def _get_test_case_no_constraint():

--- a/tests/optimagic/parameters/test_tree_conversion.py
+++ b/tests/optimagic/parameters/test_tree_conversion.py
@@ -1,9 +1,9 @@
 import numpy as np
 import pandas as pd
 import pytest
-from optimagic.parameters.tree_conversion import get_tree_converter
 from numpy.testing import assert_array_equal as aae
 from optimagic.parameters.bounds import Bounds
+from optimagic.parameters.tree_conversion import get_tree_converter
 
 
 @pytest.fixture()

--- a/tests/optimagic/shared/test_process_function.py
+++ b/tests/optimagic/shared/test_process_function.py
@@ -1,8 +1,8 @@
 import pytest
 from optimagic.exceptions import InvalidKwargsError
 from optimagic.shared.process_user_function import (
-    process_func_of_params,
     get_kwargs_from_args,
+    process_func_of_params,
 )
 
 

--- a/tests/optimagic/test_deprecations.py
+++ b/tests/optimagic/test_deprecations.py
@@ -4,29 +4,33 @@ This also serves as an internal overview of deprecated functions.
 
 """
 
-import pytest
-import numpy as np
-
-from estimagic import minimize
-from estimagic import maximize
-from estimagic import first_derivative
-from estimagic import second_derivative
-from estimagic import get_benchmark_problems
-from estimagic import run_benchmark
-from estimagic import convergence_report
-from estimagic import rank_report
-from estimagic import traceback_report
-from estimagic import profile_plot
-from estimagic import convergence_plot
-from estimagic import slice_plot
-from estimagic import check_constraints
-from estimagic import count_free_params
-from estimagic import utilities
-from estimagic import OptimizeLogReader, OptimizeResult
-from estimagic import criterion_plot, params_plot
-import optimagic as om
-import estimagic as em
 import warnings
+
+import estimagic as em
+import numpy as np
+import optimagic as om
+import pytest
+from estimagic import (
+    OptimizeLogReader,
+    OptimizeResult,
+    check_constraints,
+    convergence_plot,
+    convergence_report,
+    count_free_params,
+    criterion_plot,
+    first_derivative,
+    get_benchmark_problems,
+    maximize,
+    minimize,
+    params_plot,
+    profile_plot,
+    rank_report,
+    run_benchmark,
+    second_derivative,
+    slice_plot,
+    traceback_report,
+    utilities,
+)
 from optimagic.parameters.bounds import Bounds
 
 # ======================================================================================

--- a/tests/optimagic/test_utilities.py
+++ b/tests/optimagic/test_utilities.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from numpy.testing import assert_array_almost_equal as aaae
 from optimagic.config import IS_JAX_INSTALLED
 from optimagic.utilities import (
     calculate_trustregion_initial_radius,
@@ -23,7 +24,6 @@ from optimagic.utilities import (
     sds_and_corr_to_cov,
     to_pickle,
 )
-from numpy.testing import assert_array_almost_equal as aaae
 
 if IS_JAX_INSTALLED:
     import jax.numpy as jnp

--- a/tests/optimagic/visualization/test_history_plots.py
+++ b/tests/optimagic/visualization/test_history_plots.py
@@ -3,8 +3,8 @@ import itertools
 import numpy as np
 import pytest
 from optimagic.optimization.optimize import minimize
-from optimagic.visualization.history_plots import criterion_plot, params_plot
 from optimagic.parameters.bounds import Bounds
+from optimagic.visualization.history_plots import criterion_plot, params_plot
 
 
 @pytest.fixture()

--- a/tests/optimagic/visualization/test_profile_plot.py
+++ b/tests/optimagic/visualization/test_profile_plot.py
@@ -4,9 +4,9 @@ import pytest
 from optimagic import get_benchmark_problems
 from optimagic.benchmarking.run_benchmark import run_benchmark
 from optimagic.visualization.profile_plot import (
-    create_solution_times,
     _determine_alpha_grid,
     _find_switch_points,
+    create_solution_times,
     profile_plot,
 )
 

--- a/tests/optimagic/visualization/test_slice_plot.py
+++ b/tests/optimagic/visualization/test_slice_plot.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
-from optimagic.visualization.slice_plot import slice_plot
 from optimagic.parameters.bounds import Bounds
+from optimagic.visualization.slice_plot import slice_plot
 
 
 @pytest.fixture()


### PR DESCRIPTION
- Activate isort rule in ruff (rule "I")
- Bump mypy version to 1.11
  This entails a behavior change compared to 1.10; see diff [here](https://github.com/OpenSourceEconomics/optimagic/pull/510/commits/5f4108c66f3439c84549e4fc37c5c4d5175ada31). 